### PR TITLE
Fixed bug preventing file rename in different cases

### DIFF
--- a/LyndaDecryptor/Decryptor.cs
+++ b/LyndaDecryptor/Decryptor.cs
@@ -128,6 +128,8 @@ namespace LyndaDecryptor
 
             if (!string.IsNullOrWhiteSpace(outputFolder))
                 OutputDirectory = Directory.Exists(outputFolder) ? new DirectoryInfo(outputFolder) : Directory.CreateDirectory(outputFolder);
+            if (OutputDirectory == null)
+                OutputDirectory = new DirectoryInfo(folderPath);
 
             foreach (string entry in Directory.EnumerateFiles(folderPath, "*.lynda", SearchOption.AllDirectories))
             {

--- a/LyndaDecryptor/Program.cs
+++ b/LyndaDecryptor/Program.cs
@@ -46,7 +46,7 @@ namespace LyndaDecryptor
                     
 
                 if (decryptorOptions.UsageMode == Mode.Folder)
-                    decryptor.DecryptAll(decryptorOptions.InputPath, decryptorOptions.OutputPath);
+                    decryptor.DecryptAll(decryptorOptions.InputPath, decryptorOptions.OutputFolder);
                 else if (decryptorOptions.UsageMode == Mode.File)
                     decryptor.Decrypt(decryptorOptions.InputPath, decryptorOptions.OutputPath);
             }


### PR DESCRIPTION
Fixed bug: when no output directory was specified, database was specified and a whole folder was converted the files were not renamed according to the database.

Use OutputFolder /OUT instead of outputpath from /F when converting an entire directory